### PR TITLE
Frontend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     build: ./frontend
     volumes:
       - ./frontend:/app/frontend
+      - /app/frontend/node_modules
     depends_on:
       - customer_service
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,15 +5,15 @@ RUN mkdir -p /app/frontend
 WORKDIR /app/frontend
 
 # Add node module binaries to path
-ENV PATH /app/node_modules/.bin:$PATH
+ENV PATH ./node_modules/.bin:$PATH
 
 # Install deps
 COPY package.json ./
 COPY package-lock.json ./
-RUN npm install --silent
+RUN npm install
 
 # Copy application
-COPY . /app/frontend
+COPY . .
 
 # Start dev server
 CMD ["npm", "run", "dev"]


### PR DESCRIPTION
Fix #43 

Use an explicit Dockerfile for the frontend container
Create a volume for the frontend container's `node_modules`